### PR TITLE
added BiocManager and R Studio API installation

### DIFF
--- a/CSV-to-FCS v2.0.R
+++ b/CSV-to-FCS v2.0.R
@@ -9,9 +9,24 @@
 ##### USER INPUT #####
 
     # Install packages if required
-    if(!require('flowCore')) {install.packages('flowCore')}
-    if(!require('Biobase')) {install.packages('Biobase')}
+    rver = R.version
+    if (rver$major < 3 || (rver$major == 3 && rver.minor <= 5)){
+      # keep backwards compatibility for older R versions
+      if(!require('flowCore')) {install.packages('flowCore')}
+      if(!require('Biobase')) {install.packages('Biobase')}
+    } else {
+      # using BiocManager for future compatibility with R
+      if(!requireNamespace("BiocManager", quietly = TRUE))
+      {
+        # there's usually no need to install from source, install remote packages instead
+        install.packages("BiocManager", quiet = TRUE)
+        # the update argument suppresses BiocManager's automated update dialog prompt
+        if(!require('flowCore')) {BiocManager::install("flowCore", update = FALSE)}
+        if(!require('Biobase')) {BiocManager::install("Biobase", update = FALSE)}
+      }
+    }
     if(!require('data.table')) {install.packages('data.table')}
+    if(!require('rstudioapi')) {install.packages('rstudioapi')}
 
     # Load packages
     library('flowCore')

--- a/FCS-to-CSV v2.0.R
+++ b/FCS-to-CSV v2.0.R
@@ -9,9 +9,24 @@
 ##### USER INPUT #####
     
     # Install packages if required
-    if(!require('flowCore')) {install.packages('flowCore')}
-    if(!require('Biobase')) {install.packages('Biobase')}
+    rver = R.version
+    if (rver$major < 3 || (rver$major == 3 && rver.minor <= 5)){
+      # keep backwards compatibility for older R versions
+      if(!require('flowCore')) {install.packages('flowCore')}
+      if(!require('Biobase')) {install.packages('Biobase')}
+    } else {
+      # using BiocManager for future compatibility with R
+      if(!requireNamespace("BiocManager", quietly = TRUE))
+      {
+        # there's usually no need to install from source, install remote packages instead
+        install.packages("BiocManager", quiet = TRUE)
+        # the update argument suppresses BiocManager's automated update dialog prompt
+        if(!require('flowCore')) {BiocManager::install("flowCore", update = FALSE)}
+        if(!require('Biobase')) {BiocManager::install("Biobase", update = FALSE)}
+      }
+    }
     if(!require('data.table')) {install.packages('data.table')}
+    if(!require('rstudioapi')) {install.packages('rstudioapi')}
     
     # Load packages
     library('flowCore')


### PR DESCRIPTION
Hello @tomashhurst,

Please check the attached code changes for your platforms:
I've tested this updated with R version 4.0.4 and RStudio 1.4.1106.

For R versions below 3.5, the current package installation is kept. This choice is [somewhat arbitrary](https://www.bioconductor.org/install/#Legacy), because Bioconductor technically [supports even older R versions](http://www.bioconductor.org/about/release-announcements/) - but we don't want to break anything for existing users of the script.

For R versions above 3.5, we're using BiocManager to install the required packages. BiocManager likes to updated packages with every install call, thereby forcing the script to throw all lines of code (for the first installation run of the script) at [the update prompt](https://community.rstudio.com/t/update-all-some-none-a-s-n/11430). However, we can suppress the update prompt with the update argument in the install call set to FALSE.

I've noticed that the code refers to the R Studio API at a later point. Just in case the user wants to use the current ~~library~~ folder (it's the default), I've added this installation to the updated code block.

Please let me know, if this update works for you or if you recommend changes.

Chris